### PR TITLE
Add missing file in Makefile + miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+libmd.a
+libmd.so
+*~

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ libmd.a: $(OBJS) $(INCS)
 #	$(AR) @libmd.rf
 	$(RANLIB) libmd.a
 
+libmd.so:
+	$(CC) -shared $(OBJS) -o libmd.so
+
 # If the following are all commented out, the C versions
 # will be used by default.
 
@@ -106,6 +109,7 @@ clean:
 	rm -f paranoia
 	rm -f dcalc
 	rm -f libmd.a
+	rm -f libmd.so
 	rm -f time-it
 	rm -f dtestvec
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile for unix or GCC
 
 CC = gcc
-CFLAGS = -g -O2 -Wall -fno-builtin
+CFLAGS = -g -O2 -Wall -fno-builtin -fPIC
 AR = ar
 RANLIB = ranlib
 INCS = mconf.h

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ AS = as
 
 OBJS = acosh.o airy.o asin.o asinh.o atan.o atanh.o bdtr.o beta.o \
 btdtr.o cbrt.o chbevl.o chdtr.o clog.o cmplx.o const.o \
-cosh.o dawsn.o drand.o ellie.o ellik.o ellpe.o ellpj.o ellpk.o \
+cosh.o dawsn.o drand.o ei.o ellie.o ellik.o ellpe.o ellpj.o ellpk.o \
 exp.o exp10.o exp2.o expn.o expx2.o fabs.o fac.o fdtr.o \
 fresnl.o gamma.o gdtr.o hyp2f1.o hyperg.o i0.o i1.o igami.o \
 incbet.o incbi.o igam.o isnan.o iv.o j0.o j1.o jn.o jv.o k0.o k1.o \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ AS = as
 OBJS = acosh.o airy.o asin.o asinh.o atan.o atanh.o bdtr.o beta.o \
 btdtr.o cbrt.o chbevl.o chdtr.o clog.o cmplx.o const.o \
 cosh.o dawsn.o drand.o ellie.o ellik.o ellpe.o ellpj.o ellpk.o \
-exp.o exp10.o exp2.o expn.o fabs.o fac.o fdtr.o \
+exp.o exp10.o exp2.o expn.o expx2.o fabs.o fac.o fdtr.o \
 fresnl.o gamma.o gdtr.o hyp2f1.o hyperg.o i0.o i1.o igami.o \
 incbet.o incbi.o igam.o isnan.o iv.o j0.o j1.o jn.o jv.o k0.o k1.o \
 kn.o log.o log2.o log10.o lrand.o nbdtr.o ndtr.o ndtri.o pdtr.o \


### PR DESCRIPTION
This commit includes a small number of minor changes. 

Importantly, `expx2.o` and `ei.o` were missing in the `Makefile`. I also needed to add the `-fPIC` flag for this to compile on a recent `gcc`. I have included a `.gitignore` file and added a `libmd.so` task.

I hope that this is useful.

Sincerely, Mark.